### PR TITLE
fix: add dark mode background for code filename header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Add dark mode background override for code filename header bar.
+
 ## 0.19.0 (2026-04-10)
 
 ### Bug Fixes

--- a/_extensions/mcanouil/html/theme.scss
+++ b/_extensions/mcanouil/html/theme.scss
@@ -1903,6 +1903,11 @@ div.sourceCode {
   // Filename header (title bar)
   .code-with-filename-file {
     background-color: body-mix(92%);
+
+    .quarto-dark & {
+      background-color: body-mix(92%);
+    }
+
     border-bottom: 1px solid rgba($body-color, 0.5);
     padding: 0.2em 1em;
     line-height: 1.2;
@@ -2773,7 +2778,7 @@ figure {
 // ===========================
 
 // TOC link border-left: override Quarto's #e9ecef with brand colour
-.sidebar nav[role="doc-toc"] > ul a {
+.sidebar nav[role="doc-toc"]>ul a {
   border-left-color: rgba($body-color, 0.1);
 }
 


### PR DESCRIPTION
The filename header bar in code-with-filename blocks does not receive an explicit dark mode background override, so it inherits the light-compiled `body-mix(92%)` value when the page switches to dark mode.  Add a `.quarto-dark` scoped override so the header background resolves against the dark palette.  Also normalise whitespace around the child combinator in the TOC sidebar selector.