### PR TITLE
fix: add explicit background colour to tab content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Add explicit background colour to tab content to prevent background bleed-through.
+
 ## 0.19.1 (2026-04-12)
 
 ### Bug Fixes

--- a/_extensions/mcanouil/html/theme.scss
+++ b/_extensions/mcanouil/html/theme.scss
@@ -529,6 +529,7 @@ pre.code-annotation-code {
 // Tab content borders (Quarto/Bootstrap default is #dee2e6)
 .tab-content {
   border-color: rgba($body-color, 0.15);
+  background-color: $body-bg;
 }
 
 // Tooltips


### PR DESCRIPTION
Set `background-color` to `$body-bg` on `.tab-content` to prevent parent background bleed-through in tabbed panels.