### PR TITLE
refactor: Target Quarto Wizard v2 extension schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Refactoring
+
+- refactor: Target the Quarto Wizard v2 extension schema in `_schema.yml`, renaming `min` and `max` to `minimum` and `maximum`, and `enum-case-insensitive` to `enumCaseInsensitive`.
+
 ## 0.20.1 (2026-08-01)
 
 ### Documentation

--- a/_extensions/mcanouil/_schema.yml
+++ b/_extensions/mcanouil/_schema.yml
@@ -2,7 +2,7 @@
 # Provides configuration validation and IDE support for options,
 # shortcodes, formats, attributes, and classes.
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   grid-background:
@@ -130,8 +130,8 @@ shortcodes:
       value:
         type: integer
         default: 0
-        min: 0
-        max: 100
+        minimum: 0
+        maximum: 100
         description: "Progress percentage (0 to 100)."
       label:
         type: string
@@ -176,7 +176,7 @@ formats:
       type: string
       default: "professional"
       enum: [professional, academic]
-      enum-case-insensitive: true
+      enumCaseInsensitive: true
       description: "Template style variant for the HTML format."
     title-block-authors:
       type: boolean
@@ -196,7 +196,7 @@ formats:
       type: string
       default: "report"
       enum: [report, invoice, letter, cv]
-      enum-case-insensitive: true
+      enumCaseInsensitive: true
       description: "Document type template to use."
     brand-mode:
       type: string
@@ -207,7 +207,7 @@ formats:
       type: string
       default: "professional"
       enum: [professional, academic]
-      enum-case-insensitive: true
+      enumCaseInsensitive: true
       description: "Template style variant."
     show-corner-brackets:
       type: boolean


### PR DESCRIPTION
Points `_schema.yml` at the Quarto Wizard v2 meta-schema, renames `min` and `max` to `minimum` and `maximum` on the `progress` shortcode, and `enum-case-insensitive` to `enumCaseInsensitive` on the format `style` and `document-type` options. v2 uses JSON Schema 2020-12 canonical names exclusively, so the v1 spellings no longer validate and editors ignored the bounds and the flag.