### PR TITLE
fix: keep unaccepted attributes out of the Typst call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: A shortcode attribute the schema does not accept no longer fails a Typst build. The attribute is left out of the Typst call and reported, as it is for HTML and Reveal.js. (#130)
+- fix: A shortcode attribute written with a documented alias now reaches Typst under the name the schema declares. (#130)
+
 ## 0.21.0 (2026-09-07)
 
 ### New Features

--- a/_extensions/mcanouil/_modules/typst-utils.lua
+++ b/_extensions/mcanouil/_modules/typst-utils.lua
@@ -63,26 +63,68 @@ M.typst_value = function(value)
   return '"' .. M.escape_attribute_value(value) .. '"'
 end
 
+--- Map every spelling a shortcode accepts to the name the schema declares.
+--- A Typst function rejects a named argument it does not declare, so a key that
+--- the schema does not accept must not reach it, and an alias must arrive under
+--- the declared name. Under html an unknown key is ignored by the renderer and
+--- reported by the schema check; this gives Typst the same behaviour.
+---
+--- @param schema table|nil Parsed schema, as held by the shortcode's checker
+--- @param shortcode_name string Shortcode name as the schema declares it
+--- @return table|nil Map of accepted spelling to declared name, or nil when the
+---   schema declares no attributes for this shortcode
+--- @usage local spellings = M.accepted_attributes(checker.schema, 'value-box')
+M.accepted_attributes = function(schema, shortcode_name)
+  local entry = schema and schema.shortcodes and schema.shortcodes[shortcode_name]
+  if type(entry) ~= 'table' or type(entry.attributes) ~= 'table' then
+    return nil
+  end
+
+  local spellings = {}
+  for name, descriptor in pairs(entry.attributes) do
+    spellings[name] = name
+    if type(descriptor) == 'table' and type(descriptor.aliases) == 'table' then
+      for _, alias in ipairs(descriptor.aliases) do
+        spellings[alias] = name
+      end
+    end
+  end
+
+  return spellings
+end
+
 --- Build Typst function call for shortcodes with optional parameter mapping.
 --- Generates a complete Typst function call with attributes from keyword arguments.
 --- Supports parameter name mapping for localisation or compatibility purposes.
 ---
+--- When `spellings` is given, a key it does not list is left out of the call and
+--- an alias is emitted under the name the schema declares. Without it every key
+--- is forwarded, which is what callers that pass no schema still get.
+---
 --- @param function_name string The Typst function name (e.g., 'mcanouil-progress')
 --- @param kwargs table Keyword arguments to pass as function parameters
 --- @param param_mapping table|nil Optional parameter name mappings (e.g., {old_name = 'new_name'})
+--- @param spellings table|nil Accepted spelling to declared name, from `M.accepted_attributes`
 --- @return string Complete Typst function call (e.g., '#mcanouil-progress(value: 75)[]')
 --- @usage local code = M.build_shortcode_function_call('mcanouil-progress', {value = 75})
 --- @usage local code = M.build_shortcode_function_call('mcanouil-progress', {colour = 'blue'})
-M.build_shortcode_function_call = function(function_name, kwargs, param_mapping)
+M.build_shortcode_function_call = function(function_name, kwargs, param_mapping, spellings)
   -- Build attribute string
   local attr_items = {}
   for key, value in pairs(kwargs) do
-    -- Apply parameter name mapping if provided
-    local typst_key = key
-    if param_mapping and param_mapping[key] then
-      typst_key = param_mapping[key]
+    local declared_key = key
+    if spellings then
+      declared_key = spellings[key]
     end
-    table.insert(attr_items, string.format('%s: %s', typst_key, M.typst_value(value)))
+
+    if declared_key then
+      -- Apply parameter name mapping if provided
+      local typst_key = declared_key
+      if param_mapping and param_mapping[declared_key] then
+        typst_key = param_mapping[declared_key]
+      end
+      table.insert(attr_items, string.format('%s: %s', typst_key, M.typst_value(value)))
+    end
   end
 
   -- Generate function call

--- a/_extensions/mcanouil/shortcodes/divider.lua
+++ b/_extensions/mcanouil/shortcodes/divider.lua
@@ -57,7 +57,11 @@ return {
 
     if format == 'typst' then
       -- Typst rendering
-      return pandoc.RawBlock('typst', typst_utils.build_shortcode_function_call('mcanouil-divider', kwargs))
+      local spellings = typst_utils.accepted_attributes(checker.schema, 'divider')
+      return pandoc.RawBlock(
+        'typst',
+        typst_utils.build_shortcode_function_call('mcanouil-divider', kwargs, nil, spellings)
+      )
     elseif format == 'html' or format == 'revealjs' then
       -- HTML-based rendering
       local config = format_utils.get_config()

--- a/_extensions/mcanouil/shortcodes/progress.lua
+++ b/_extensions/mcanouil/shortcodes/progress.lua
@@ -57,7 +57,11 @@ return {
 
     if format == 'typst' then
       -- Typst rendering
-      return pandoc.RawBlock('typst', typst_utils.build_shortcode_function_call('mcanouil-progress', kwargs))
+      local spellings = typst_utils.accepted_attributes(checker.schema, 'progress')
+      return pandoc.RawBlock(
+        'typst',
+        typst_utils.build_shortcode_function_call('mcanouil-progress', kwargs, nil, spellings)
+      )
     elseif format == 'html' or format == 'revealjs' then
       -- HTML-based rendering
       local config = format_utils.get_config()

--- a/_extensions/mcanouil/shortcodes/value-box.lua
+++ b/_extensions/mcanouil/shortcodes/value-box.lua
@@ -57,7 +57,11 @@ return {
 
     if format == 'typst' then
       -- Typst rendering
-      return pandoc.RawBlock('typst', typst_utils.build_shortcode_function_call('mcanouil-value-box', kwargs))
+      local spellings = typst_utils.accepted_attributes(checker.schema, 'value-box')
+      return pandoc.RawBlock(
+        'typst',
+        typst_utils.build_shortcode_function_call('mcanouil-value-box', kwargs, nil, spellings)
+      )
     elseif format == 'html' or format == 'revealjs' then
       -- HTML-based rendering
       local config = format_utils.get_config()


### PR DESCRIPTION
An attribute the schema does not accept was forwarded verbatim to Typst, which rejected it and failed the build. Under HTML and Reveal.js the same attribute is only reported. The Typst call now carries the attributes the schema declares, and an attribute written with a documented alias arrives under the declared name.