### PR TITLE
fix: accept a colour name in Typst components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Accept a Typst colour name, such as `blue`, in the `colour` attribute of `value-box` and `.card`. Both stopped a Typst build on a name rather than colouring anything, and a value that names no colour now keeps the component's default.
+
 ### Documentation
 
 - docs: Serve the extension's social card as the Open Graph image, so a shared link shows the card rather than the first image on the page. (#132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- fix: Accept a Typst colour name, such as `blue`, in the `colour` attribute of `value-box` and `.card`. Both stopped a Typst build on a name rather than colouring anything, and a value that names no colour now keeps the component's default.
+- fix: Accept a Typst colour name, such as `blue`, in the `colour` attribute of `value-box` and `.card` in Typst output. Both stopped the build on a name rather than colouring anything, and a malformed hex code stopped it as well. A value that names no colour now uses the component's fallback colour instead of stopping the build.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- fix: Accept a Typst colour name, such as `blue`, in the `colour` attribute of `value-box` and `.card` in Typst output. Both stopped the build on a name rather than colouring anything, and a malformed hex code stopped it as well. A value that names no colour now uses the component's fallback colour instead of stopping the build.
+- fix: Accept a Typst colour name, such as `blue`, in the `colour` attribute of `value-box` and `.card` in Typst output. Both stopped the build on a name rather than colouring anything, and a malformed hex code stopped it as well. A value that names no colour now uses the component's fallback colour instead of stopping the build. (#134)
 
 ### Documentation
 

--- a/_extensions/mcanouil/_modules/typst-card-grid.lua
+++ b/_extensions/mcanouil/_modules/typst-card-grid.lua
@@ -87,12 +87,10 @@ local function process_card_grid(div, config)
       table.insert(card_parts, string.format('style: %s', typst_utils.typst_value(card.style)))
     end
     if card.colour then
-      -- Hex colours need rgb() wrapper, other values use typst_value()
-      if card.colour:match('^#') then
-        table.insert(card_parts, string.format('colour: rgb(%s)', typst_utils.typst_value(card.colour)))
-      else
-        table.insert(card_parts, string.format('colour: %s', typst_utils.typst_value(card.colour)))
-      end
+      -- Passed as a string, hex or name alike. The Typst side resolves it, and
+      -- wrapping a hex value in `rgb()` here would raise on a malformed one
+      -- before that resolution could keep the card's default.
+      table.insert(card_parts, string.format('colour: %s', typst_utils.typst_value(card.colour)))
     end
 
     table.insert(card_items, '(' .. table.concat(card_parts, ', ') .. ')')
@@ -129,11 +127,10 @@ local function process_card_div(div, config)
     table.insert(parts, string.format('style: %s', typst_utils.typst_value(card.style)))
   end
   if card.colour then
-    if card.colour:match('^#') then
-      table.insert(parts, string.format('colour: rgb(%s)', typst_utils.typst_value(card.colour)))
-    else
-      table.insert(parts, string.format('colour: %s', typst_utils.typst_value(card.colour)))
-    end
+    -- Passed as a string, hex or name alike. The Typst side resolves it, and
+    -- wrapping a hex value in `rgb()` here would raise on a malformed one
+    -- before that resolution could keep the card's default.
+    table.insert(parts, string.format('colour: %s', typst_utils.typst_value(card.colour)))
   end
 
   local args_str = ''

--- a/_extensions/mcanouil/_schema.yml
+++ b/_extensions/mcanouil/_schema.yml
@@ -306,7 +306,7 @@ attributes:
     colour:
       type: string
       aliases: [color]
-      description: "Custom accent colour for the card: a hex code, or in Typst output a colour name such as blue. HTML ignores a name. A value naming no colour uses the muted colour."
+      description: "Custom accent colour for the card: a hex code or a colour name such as blue, honoured in both HTML and Typst output. In Typst a value naming no colour uses the muted colour."
       completion:
         type: color
 

--- a/_extensions/mcanouil/_schema.yml
+++ b/_extensions/mcanouil/_schema.yml
@@ -120,7 +120,7 @@ shortcodes:
         type: string
         default: "info"
         aliases: [color]
-        description: "Colour theme or custom colour value."
+        description: "Colour theme (success, warning, danger, info, neutral), a Typst colour name such as blue, or a hex code. An unknown value keeps the default."
         completion:
           type: color
 
@@ -140,7 +140,7 @@ shortcodes:
         type: string
         default: "info"
         aliases: [color]
-        description: "Colour theme or custom colour value."
+        description: "Colour theme (success, warning, danger, info, neutral) or a hex code. Any other value falls back to the info colour."
         completion:
           type: color
       show-value:
@@ -306,7 +306,7 @@ attributes:
     colour:
       type: string
       aliases: [color]
-      description: "Custom accent colour for the card."
+      description: "Custom accent colour for the card: a Typst colour name such as blue, or a hex code. An unknown value keeps the default."
       completion:
         type: color
 

--- a/_extensions/mcanouil/_schema.yml
+++ b/_extensions/mcanouil/_schema.yml
@@ -120,7 +120,7 @@ shortcodes:
         type: string
         default: "info"
         aliases: [color]
-        description: "Colour theme (success, warning, danger, info, neutral), a Typst colour name such as blue, or a hex code. An unknown value keeps the default."
+        description: "Colour theme (success, warning, danger, info, neutral) or a hex code. Typst output also accepts a colour name such as blue; HTML ignores a name. A value naming no colour uses the foreground colour."
         completion:
           type: color
 
@@ -306,7 +306,7 @@ attributes:
     colour:
       type: string
       aliases: [color]
-      description: "Custom accent colour for the card: a Typst colour name such as blue, or a hex code. An unknown value keeps the default."
+      description: "Custom accent colour for the card: a hex code, or in Typst output a colour name such as blue. HTML ignores a name. A value naming no colour uses the muted colour."
       completion:
         type: color
 

--- a/_extensions/mcanouil/typst/partials/libs/card-grid.typ
+++ b/_extensions/mcanouil/typst/partials/libs/card-grid.typ
@@ -46,16 +46,7 @@
   // A div attribute arrives as a string, so a hex value or a colour name has to
   // become a colour first. `rgb` alone stops the build on a name, so an
   // unresolved value keeps the default rather than removing the document.
-  let card-colour = if type(card-colour-raw) == str {
-    let resolved = resolve-colour(card-colour-raw)
-    if resolved != none {
-      resolved
-    } else {
-      colours.muted
-    }
-  } else {
-    card-colour-raw
-  }
+  let card-colour = resolve-colour-or(card-colour-raw, colours.muted)
 
   // Determine card styling based on style
   let (bg-colour, border-colour, title-colour, header-bg, content-colour) = if card-style == "filled" {

--- a/_extensions/mcanouil/typst/partials/libs/card-grid.typ
+++ b/_extensions/mcanouil/typst/partials/libs/card-grid.typ
@@ -43,9 +43,16 @@
   let card-colour-raw = config.at("colour", default: colours.muted)
   let card-style = config.at("style", default: "subtle")
 
-  // Convert colour string to colour object if needed
+  // A div attribute arrives as a string, so a hex value or a colour name has to
+  // become a colour first. `rgb` alone stops the build on a name, so an
+  // unresolved value keeps the default rather than removing the document.
   let card-colour = if type(card-colour-raw) == str {
-    rgb(card-colour-raw)
+    let resolved = resolve-colour(card-colour-raw)
+    if resolved != none {
+      resolved
+    } else {
+      colours.muted
+    }
   } else {
     card-colour-raw
   }

--- a/_extensions/mcanouil/typst/partials/libs/colours.typ
+++ b/_extensions/mcanouil/typst/partials/libs/colours.typ
@@ -163,10 +163,13 @@
 /// @param value Attribute value
 /// @return Color, or none when the value resolves to no colour
 #let resolve-colour(value) = {
-  if type(value) == color {
-    value
-  } else if type(value) != str {
+  if value == none {
     none
+  } else if type(value) != str {
+    // A colour, a gradient or a tiling arrives already built, from an attribute
+    // that Typst read as an expression rather than a string. Passed through, so
+    // this stays a string resolver and narrows nothing.
+    value
   } else {
     // Trimmed once, so a name and a hex value tolerate surrounding space alike.
     let text = value.trim()
@@ -213,8 +216,14 @@
   } else if colour-type == "neutral" {
     colour-mix(colours, 50%)
   } else if type(colour-type) == str and colour-type.starts-with("#") {
-    // Custom hex colour
-    rgb(colour-type)
+    // Custom hex colour. Resolved rather than passed straight to `rgb`, which
+    // raises on a malformed value and would stop the build over a typo.
+    let resolved = resolve-colour(colour-type)
+    if resolved != none {
+      resolved
+    } else {
+      COLOUR-SEMANTIC-INFO
+    }
   } else {
     // Default to info colour
     COLOUR-SEMANTIC-INFO

--- a/_extensions/mcanouil/typst/partials/libs/colours.typ
+++ b/_extensions/mcanouil/typst/partials/libs/colours.typ
@@ -167,9 +167,17 @@
     none
   } else if type(value) != str {
     // A colour, a gradient or a tiling arrives already built, from an attribute
-    // that Typst read as an expression rather than a string. Passed through, so
-    // this stays a string resolver and narrows nothing.
-    value
+    // that Typst read as an expression rather than a string. Those pass through.
+    // Anything else, such as a number or a boolean, is not a paint and would
+    // stop the build further on, so it resolves to nothing instead.
+    // The kind is compared as a name because `tiling` was `pattern` in earlier
+    // Typst, and naming the missing one directly would raise here.
+    let kind = str(type(value))
+    if kind == "color" or kind == "gradient" or kind == "tiling" or kind == "pattern" {
+      value
+    } else {
+      none
+    }
   } else {
     // Trimmed once, so a name and a hex value tolerate surrounding space alike.
     let text = value.trim()
@@ -191,6 +199,21 @@
     } else {
       NAMED-COLOURS.at(lower(text), default: none)
     }
+  }
+}
+
+/// Resolve an attribute value to a colour, or to the caller's default.
+/// Every component that reads a colour attribute wants the same thing: the
+/// value when it names a colour, and its own fallback when it does not.
+/// @param value Attribute value
+/// @param default Colour to use when the value names no colour
+/// @return Color
+#let resolve-colour-or(value, default) = {
+  let resolved = resolve-colour(value)
+  if resolved != none {
+    resolved
+  } else {
+    default
   }
 }
 
@@ -218,12 +241,7 @@
   } else if type(colour-type) == str and colour-type.starts-with("#") {
     // Custom hex colour. Resolved rather than passed straight to `rgb`, which
     // raises on a malformed value and would stop the build over a typo.
-    let resolved = resolve-colour(colour-type)
-    if resolved != none {
-      resolved
-    } else {
-      COLOUR-SEMANTIC-INFO
-    }
+    resolve-colour-or(colour-type, COLOUR-SEMANTIC-INFO)
   } else {
     // Default to info colour
     COLOUR-SEMANTIC-INFO

--- a/_extensions/mcanouil/typst/partials/libs/colours.typ
+++ b/_extensions/mcanouil/typst/partials/libs/colours.typ
@@ -129,6 +129,49 @@
 #let COLOUR-SEMANTIC-DANGER = rgb("#cc0000")   // 5.9:1 contrast
 #let COLOUR-SEMANTIC-INFO = rgb("#0066cc")     // 7.5:1 contrast
 
+/// The colours Typst names in its standard library.
+/// A shortcode attribute arrives as a string, so a name has to be looked up
+/// before any colour function sees it.
+#let NAMED-COLOURS = (
+  black: black,
+  gray: gray,
+  grey: gray,
+  silver: silver,
+  white: white,
+  navy: navy,
+  blue: blue,
+  aqua: aqua,
+  teal: teal,
+  eastern: eastern,
+  purple: purple,
+  fuchsia: fuchsia,
+  maroon: maroon,
+  red: red,
+  orange: orange,
+  yellow: yellow,
+  olive: olive,
+  green: green,
+  lime: lime,
+)
+
+/// Resolve an attribute value to a colour.
+/// Accepts a colour, a hex string such as "#ff0000", or a colour name such as
+/// "blue". Returns `none` when the value names no colour, so the caller keeps
+/// its own default rather than passing a string on to a colour function.
+/// @param value Attribute value
+/// @return Color, or none when the value resolves to no colour
+#let resolve-colour(value) = {
+  if type(value) == color {
+    value
+  } else if type(value) != str {
+    none
+  } else if value.starts-with("#") {
+    rgb(value)
+  } else {
+    NAMED-COLOURS.at(lower(value.trim()), default: none)
+  }
+}
+
 /// Get semantic colour for UI components (success, warning, danger, info, neutral)
 /// Automatically adjusts brightness for dark mode to maintain WCAG contrast.
 /// @param colour-type Colour type string or custom hex colour

--- a/_extensions/mcanouil/typst/partials/libs/colours.typ
+++ b/_extensions/mcanouil/typst/partials/libs/colours.typ
@@ -158,6 +158,8 @@
 /// Accepts a colour, a hex string such as "#ff0000", or a colour name such as
 /// "blue". Returns `none` when the value names no colour, so the caller keeps
 /// its own default rather than passing a string on to a colour function.
+/// A malformed hex value returns `none` as well: `rgb` stops the build on one,
+/// and a fault in the configuration must not remove the document.
 /// @param value Attribute value
 /// @return Color, or none when the value resolves to no colour
 #let resolve-colour(value) = {
@@ -165,10 +167,27 @@
     value
   } else if type(value) != str {
     none
-  } else if value.starts-with("#") {
-    rgb(value)
   } else {
-    NAMED-COLOURS.at(lower(value.trim()), default: none)
+    // Trimmed once, so a name and a hex value tolerate surrounding space alike.
+    let text = value.trim()
+    if text.starts-with("#") {
+      // Typst accepts 3, 4, 6 and 8 hex digits. Anything else raises rather
+      // than returning, so the shape is checked before `rgb` sees it.
+      // Checked without a regular expression on purpose. This file is a Pandoc
+      // template, and the character that anchors a pattern to the end of a
+      // string is the one that opens a template interpolation, so an anchored
+      // pattern does not survive the template pass. It cannot appear in a
+      // comment here either.
+      let digits = lower(text.slice(1))
+      let length-ok = digits.len() == 3 or digits.len() == 4 or digits.len() == 6 or digits.len() == 8
+      if length-ok and digits.clusters().all(c => "0123456789abcdef".contains(c)) {
+        rgb(text)
+      } else {
+        none
+      }
+    } else {
+      NAMED-COLOURS.at(lower(text), default: none)
+    }
   }
 }
 

--- a/_extensions/mcanouil/typst/partials/libs/value-box.typ
+++ b/_extensions/mcanouil/typst/partials/libs/value-box.typ
@@ -30,8 +30,8 @@
 /// Get colour for value box.
 /// Supports predefined colour types or custom colour values: a Typst colour
 /// name such as "blue", a hex code, or a colour object.
-/// A value that names no colour keeps the box's default rather than stopping
-/// the build.
+/// A value that names no colour falls back to the foreground colour, which is
+/// what an absent value already gives, rather than stopping the build.
 /// Uses semantic colours (brighter) for UI components, not callout colours.
 /// @param colour Colour type (success, warning, danger, info, neutral), a colour name, or custom colour (e.g., "blue", "#ff0000", rgb(...))
 /// @param colours Colour scheme dictionary

--- a/_extensions/mcanouil/typst/partials/libs/value-box.typ
+++ b/_extensions/mcanouil/typst/partials/libs/value-box.typ
@@ -28,9 +28,12 @@
 // ============================================================================
 
 /// Get colour for value box.
-/// Supports predefined colour types or custom colour values (hex codes, rgb(), etc.).
+/// Supports predefined colour types or custom colour values: a Typst colour
+/// name such as "blue", a hex code, or a colour object.
+/// A value that names no colour keeps the box's default rather than stopping
+/// the build.
 /// Uses semantic colours (brighter) for UI components, not callout colours.
-/// @param colour Colour type (success, warning, danger, info, neutral) or custom colour (e.g., "#ff0000", rgb(...))
+/// @param colour Colour type (success, warning, danger, info, neutral), a colour name, or custom colour (e.g., "blue", "#ff0000", rgb(...))
 /// @param colours Colour scheme dictionary
 /// @return Color Colour for the value box
 #let get-value-box-colour(colour, colours) = {

--- a/_extensions/mcanouil/typst/partials/libs/value-box.typ
+++ b/_extensions/mcanouil/typst/partials/libs/value-box.typ
@@ -40,12 +40,14 @@
   } else if colour == "neutral" {
     colours.muted
   } else if colour != none and colour != "" {
-    // Custom colour value - check if it's a hex string
-    if type(colour) == str and colour.starts-with("#") {
-      rgb(colour)
+    // A hex string, a colour name, or a colour object. A shortcode attribute
+    // arrives as a string, so an unresolved one would reach a colour function
+    // as a string and stop the build; the document keeps its default instead.
+    let resolved = resolve-colour(colour)
+    if resolved != none {
+      resolved
     } else {
-      // Already a color object (rgb(), color function, etc.)
-      colour
+      colours.foreground
     }
   } else {
     colours.foreground

--- a/_extensions/mcanouil/typst/partials/libs/value-box.typ
+++ b/_extensions/mcanouil/typst/partials/libs/value-box.typ
@@ -46,12 +46,7 @@
     // A hex string, a colour name, or a colour object. A shortcode attribute
     // arrives as a string, so an unresolved one would reach a colour function
     // as a string and stop the build; the document keeps its default instead.
-    let resolved = resolve-colour(colour)
-    if resolved != none {
-      resolved
-    } else {
-      colours.foreground
-    }
+    resolve-colour-or(colour, colours.foreground)
   } else {
     colours.foreground
   }


### PR DESCRIPTION
`{{< value-box value=42 label="Answer" colour=blue >}}` stopped a Typst build with `error: expected color, found string`. A shortcode attribute arrives as a string, and `value-box` passed it to a colour function unchanged while `.card` passed it to `rgb`, so a colour name never coloured anything. The fault was pre-existing, and reproduced against unmodified code.

A shared `resolve-colour` accepts a colour name, a hex code or a value Typst already built, and returns nothing when the value names no colour. `resolve-colour-or` pairs that with each component's own fallback, so a faulty value keeps a default rather than removing the document. `semantic-colour` resolves its hex branch the same way, which also stops a malformed hex from breaking `progress` and a badge.

Verified by rendering fourteen cases, all of which now produce a PDF: a colour name, the `color` alias, a semantic name, `neutral`, a hex code, mixed case, an unknown name, an absent value, a malformed hex, a wrong-length hex, a hex with surrounding space and a numeric value, plus `.card` and `progress`. A gradient attribute still fails, identically to unmodified code, so nothing regressed there.

The schema descriptions now record what each output accepts, including that `value-box` ignores a colour name in HTML while `.card` honours it through a CSS custom property.